### PR TITLE
DOCS: add note about MyST-MD

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,7 +23,9 @@ html:
   # FIXME: surely we could allow internal or relative links somehow?
   # (The documentation says only that HTML is allowed, nothing about the base URL is mentioned.)
   # Then we could link to the changelog in the *same* build of the docs.
-  announcement: '⚠️The 0.13 release refactored our HTML, so double-check your custom CSS rules!⚠️'
+  announcement: >
+    ℹ️ Jupyter Book is being rebuilt on top of <a href="https://mystmd.org/">MyST-MD</a>. 
+    See <a href="https://executablebooks.org/en/latest/blog/2024-05-20-jupyter-book-myst/">our blog post</a> for more information. 🚀
   favicon: images/favicon.ico
   home_page_in_navbar: false
   use_edit_page_button: true


### PR DESCRIPTION
Jupyter Book is being rebuilt upon MyST-MD rather than Sphinx. Our [blog post](https://executablebooks.org/en/latest/blog/2024-05-20-jupyter-book-myst/) introduces this, and we'll eventually start putting into place documentation and other scaffolding to make this more visible. For now, just add a banner:

![image](https://github.com/user-attachments/assets/4b6029f3-f80b-4fa0-b60b-862bba6ee13b)
