### PR TITLE
docs: fix google analytics config and docs

### DIFF
--- a/docs/advanced/html.md
+++ b/docs/advanced/html.md
@@ -131,8 +131,7 @@ Analytics) into the following directive in your configuration file:
 
 ```yaml
 html:
-  analytics:
-    google_analytics_id: G-XXXXXXX
+  google_analytics_id: G-XXXXXXX
 ```
 
 :::{seealso}

--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -55,10 +55,10 @@ html:
   extra_footer              : ""  # Will be displayed underneath the footer.
   home_page_in_navbar       : true  # Whether to include your home page in the left Navigation Bar
   baseurl                   : ""  # The base URL where your book will be hosted. Used for creating image previews and social links. e.g.: https://mypage.com/mybook/
+  google_analytics_id       : ""  # A GA id that can be used to track book views.
   analytics:
     plausible_analytics_domain: my-domain
     plausible_analytics_url: "https://plausible.io/js/script.js"
-    google_analytics_id       : ""  # A GA id that can be used to track book views.
 
   comments:
     hypothesis              : false


### PR DESCRIPTION
This pull request includes updates to the configuration files for Google Analytics integration. The changes streamline the configuration by removing redundancy and ensuring consistency between documentation and default settings.

Configuration updates:

* [`docs/advanced/html.md`](diffhunk://#diff-9d2c09f1e61de17f2d3bb8d6de8f7792a0109b85a04a7c9c4aa666c6bec7f5d2L134): Removed the `analytics` directive to simplify the configuration for Google Analytics.
* [`jupyter_book/default_config.yml`](diffhunk://#diff-9b593b5f3857f2bb52dd8751a2647a33befc1dbff7e814cb4f8169cebc2e24e5R58-L61): Moved `google_analytics_id` out of the `analytics` section to the main `html` section for better clarity and consistency.

According to @MortenHannemose, the one in *Configuration defaults* docs section is correct. 

fix jupyter-book/jupyter-book#2194