### PR TITLE
⚙️ Drop `BASE_URL` in GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,10 +6,6 @@ on:
     # Runs on pushes targeting the default branch
     branches: [next]
   workflow_dispatch:
-env:
-  # `BASE_URL` determines the website is served from, including CSS & JS assets
-  # You may need to change this to `BASE_URL: ''`
-  BASE_URL: /${{ github.event.repository.name }}
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
Drop `BASE_URL` in CI now that we're deploying to `http://next.jupyterbook.org`