### PR TITLE
MAINT: only use v1 job for v1 releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
   tests:
     uses: ./.github/workflows/tests.yml
   publish:
+    # Account for v2 pre-releases
+    if: ${{ startsWith(github.event.release.tag_name, "v1") }}
     name: publish
     needs: [tests] # require tests to pass before deploy runs
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR scopes our release workflow to only apply to v1 releases.