### PR TITLE
✏️ Hardcode binary name

### DIFF
--- a/py/jupyter_book/__main__.py
+++ b/py/jupyter_book/__main__.py
@@ -57,13 +57,12 @@ def main():
 
     # Build args for Node.js process
     jb_node_args = [js_path, *sys.argv[1:]]
-    binary_name = os.path.basename(sys.argv[0])
 
     jb_env = {
         **node_env,
         "MYST_LANG": "PYTHON",
         "MYSTMD_READABLE_NAME": "Jupyter Book",
-        "MYSTMD_BINARY_NAME": binary_name,
+        "MYSTMD_BINARY_NAME": "jupyter book",
         "MYSTMD_HOME_URL": "https://jupyterbook.org",
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ file = "README.md"
 content-type = "text/markdown"
 
 [project.scripts]
-jb = "jupyter_book.__main__:main"
 jupyter-book = "jupyter_book.__main__:main"
 
 [tool.hatch.build.hooks.selector]


### PR DESCRIPTION
Previously, the Jupyter Book binary used `argv[0]` to determine the binary name. However, we want to promote a specific name: `jupyter book`, which uses the `jupyter` launcher.