### PR TITLE
✏️ Remove references to executablebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# <img src="https://raw.githubusercontent.com/executablebooks/jupyter-book/master/docs/media/images/logo-square.svg" width=40 /> Jupyter Book
+# <img src="https://raw.githubusercontent.com/jupyter-book/jupyter-book/master/docs/media/images/logo-square.svg" width=40 /> Jupyter Book
 
-[![Jupyter Book Badge](https://raw.githubusercontent.com/executablebooks/jupyter-book/master/docs/media/images/badge.svg)](https://jupyterbook.org)
+[![Jupyter Book Badge](https://raw.githubusercontent.com/jupyter-book/jupyter-book/master/docs/media/images/badge.svg)](https://jupyterbook.org)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2561065.svg)](https://doi.org/10.5281/zenodo.2561065)
 
 <!-- [![PyPI][pypi-badge]][pypi-link]

--- a/docs/about/history.md
+++ b/docs/about/history.md
@@ -19,7 +19,7 @@ gantt
 
 ## A first attempt using Jekyll
 
-The Jupyter Book project was started with [the first commit](https://github.com/executablebooks/jupyter-book/commit/4fc6636c652cebea71556f634c9a37e0740ab26f) in June of 2018. Initially, work was focussed on building a series of scripts to compile Jupyter Notebooks into a textbook using [Jekyll](https://jekyllrb.com/).
+The Jupyter Book project was started with [the first commit](https://github.com/jupyter-book/jupyter-book/commit/4fc6636c652cebea71556f634c9a37e0740ab26f) in June of 2018. Initially, work was focussed on building a series of scripts to compile Jupyter Notebooks into a textbook using [Jekyll](https://jekyllrb.com/).
 
 ## Creation of the `jupyter book` application
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -32,13 +32,13 @@ Before we can upgrade a {term}`Legacy Book`, we must first discuss its important
 
 The most important files in a {term}`Legacy Book` are the `_toc.yml` and `_config.yml` files described in [](#legacy-config-files). These files control what a book contains and what it looks like.
 
-An example {term}`Legacy Book` can be seen at <https://github.com/jupyter-book/demo-book/>. If we inspect the contents of the `my_book` directory, there are a number of files including [`_toc.yml`](#code:example-toc) and [`_config.yml`](#code:example-config):
+An example {term}`Legacy Book` can be seen at <https://github.com/jupyter-book/legacy-demo-book/>. If we inspect the contents of the `my_book` directory, there are a number of files including [`_toc.yml`](#code:example-toc) and [`_config.yml`](#code:example-config):
 
 ```{code} shell
-:caption: Contents of the {term}`Legacy Book` at <https://github.com/jupyter-book/demo-book/>.
+:caption: Contents of the {term}`Legacy Book` at <https://github.com/jupyter-book/legacy-demo-book/>.
 :name: legacy-contents
 
-$ git clone https://github.com/jupyter-book/demo-book
+$ git clone https://github.com/jupyter-book/legacy-demo-book
 $ cd demo-book
 $ ls ./my_book
 _config.yml
@@ -55,7 +55,7 @@ _toc.yml
 ```{code} yaml
 :filename: my_book/_config.yml
 :name: code:example-config
-:caption: Extract from the `_config.yml` file defined in <https://github.com/jupyter-book/demo-book/>.
+:caption: Extract from the `_config.yml` file defined in <https://github.com/jupyter-book/legacy-demo-book/>.
 
 #######################################################################################
 # A default configuration that will be loaded for all jupyter books
@@ -80,7 +80,7 @@ execute:
 ```{code} yaml
 :filename: my_book/_toc.yml
 :name: code:example-toc
-:caption: The `_toc.yml` file defined in <https://github.com/jupyter-book/demo-book/>.
+:caption: The `_toc.yml` file defined in <https://github.com/jupyter-book/legacy-demo-book/>.
 
 # Table of contents
 # Learn more at https://jupyterbook.org/customize/toc.html

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -32,13 +32,13 @@ Before we can upgrade a {term}`Legacy Book`, we must first discuss its important
 
 The most important files in a {term}`Legacy Book` are the `_toc.yml` and `_config.yml` files described in [](#legacy-config-files). These files control what a book contains and what it looks like.
 
-An example {term}`Legacy Book` can be seen at <https://github.com/executablebooks/demo-book/>. If we inspect the contents of the `my_book` directory, there are a number of files including [`_toc.yml`](#code:example-toc) and [`_config.yml`](#code:example-config):
+An example {term}`Legacy Book` can be seen at <https://github.com/jupyter-book/demo-book/>. If we inspect the contents of the `my_book` directory, there are a number of files including [`_toc.yml`](#code:example-toc) and [`_config.yml`](#code:example-config):
 
 ```{code} shell
-:caption: Contents of the {term}`Legacy Book` at <https://github.com/executablebooks/demo-book/>.
+:caption: Contents of the {term}`Legacy Book` at <https://github.com/jupyter-book/demo-book/>.
 :name: legacy-contents
 
-$ git clone https://github.com/executablebooks/demo-book
+$ git clone https://github.com/jupyter-book/demo-book
 $ cd demo-book
 $ ls ./my_book
 _config.yml
@@ -55,7 +55,7 @@ _toc.yml
 ```{code} yaml
 :filename: my_book/_config.yml
 :name: code:example-config
-:caption: Extract from the `_config.yml` file defined in <https://github.com/executablebooks/demo-book/>.
+:caption: Extract from the `_config.yml` file defined in <https://github.com/jupyter-book/demo-book/>.
 
 #######################################################################################
 # A default configuration that will be loaded for all jupyter books
@@ -80,7 +80,7 @@ execute:
 ```{code} yaml
 :filename: my_book/_toc.yml
 :name: code:example-toc
-:caption: The `_toc.yml` file defined in <https://github.com/executablebooks/demo-book/>.
+:caption: The `_toc.yml` file defined in <https://github.com/jupyter-book/demo-book/>.
 
 # Table of contents
 # Learn more at https://jupyterbook.org/customize/toc.html


### PR DESCRIPTION
This replaces executablebooks mentions with jupyter-book mentions