### PR TITLE
Add howto for plugin dependencies

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -42,8 +42,12 @@ project:
     - title: How To
       children:
         - file: execute/generate-myst.md
-        - file: plugins/directives-and-roles.md
-        - file: plugins/ast.md
+        - title: Plugins
+          children:
+          - file: plugins/directives-and-roles.md
+          - file: plugins/ast.md
+          - file: plugins/debug.md
+          - file: plugins/dependencies.md
     - title: About Jupyter Book
       children:
         - file: about/toolchain.md

--- a/docs/plugins/dependencies.md
+++ b/docs/plugins/dependencies.md
@@ -1,9 +1,6 @@
 # Install JavaScript dependencies with your plugin
 
-You can expand your plugin's functionality by installing dependencies that will be available to your MyST plugin code.
-To do so, use a `package.json` file in your plugin's root directory.[^1]
-
-[^1]: For more information about `package.json` files, see the [Node.js documentation](https://docs.npmjs.com/cli/v9/using-npm/package-json) and [the MDN package documentation](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Package_management).
+You can expand your plugin's functionality by installing dependencies from the [npm package repository][npmjs]. You can install new dependencies by defining a `package.json` file[^1] in the same directory as your `myst.yml`[^2], and running `npm install`.
 
 Here's an example `package.json` file that includes the `js-yaml` package, which is a YAML parser.
 
@@ -16,7 +13,17 @@ Here's an example `package.json` file that includes the `js-yaml` package, which
 }
 ```
 
+By running `npm install`, we see:
+```{code} shell
+$ npm install
+added 2 packages, and audited 3 packages in 898ms
+
+found 0 vulnerabilities
+````
+
 You can then use the `js-yaml` package in your plugin code by importing it.
+
+
 For example, the following JavaScript snippet uses the `js-yaml` package and the `fs` package (already built into JavaScript) to load YAML data from a file.
 
 ```{code} javascript
@@ -29,3 +36,10 @@ const someData = yaml.load(fs.readFileSync("data.yml", "utf8"));
 ```
 
 Note that any plugins will be run from the root of the project, so set your file paths accordingly.
+
+## 
+
+[^1]: For more information about `package.json` files, see the [Node.js documentation](https://docs.npmjs.com/cli/v9/using-npm/package-json) and [the MDN package documentation](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Package_management).
+[^2]: In fact, you can define a new `package.json` for each custom plugin, by defining your plugins in their own folders. There is little benefit to doing this, though.
+
+[npmjs]: https://www.npmjs.com/

--- a/docs/plugins/dependencies.md
+++ b/docs/plugins/dependencies.md
@@ -1,0 +1,31 @@
+# Install JavaScript dependencies with your plugin
+
+You can expand your plugin's functionality by installing dependencies that will be available to your MyST plugin code.
+To do so, use a `package.json` file in your plugin's root directory.[^1]
+
+[^1]: For more information about `package.json` files, see the [Node.js documentation](https://docs.npmjs.com/cli/v9/using-npm/package-json) and [the MDN package documentation](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Package_management).
+
+Here's an example `package.json` file that includes the `js-yaml` package, which is a YAML parser.
+
+```{code} json
+:filename: package.json
+{
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  }
+}
+```
+
+You can then use the `js-yaml` package in your plugin code by importing it.
+For example, the following JavaScript snippet uses the `js-yaml` package and the `fs` package (already built into JavaScript) to load YAML data from a file.
+
+```{code} javascript
+:filename: my_plugin.mjs
+import yaml from "js-yaml";
+import fs from "fs";
+
+// Read and parse team data
+const someData = yaml.load(fs.readFileSync("data.yml", "utf8"));
+```
+
+Note that any plugins will be run from the root of the project, so set your file paths accordingly.

--- a/docs/tutorial/plugins.md
+++ b/docs/tutorial/plugins.md
@@ -59,9 +59,11 @@ Next we'll create an empty JavaScript file[^esm] that we'll use to add new plugi
 
 🛠 Create a `src/` folder and add an empty JavaScript file to it
 
-```{code}
+```{code} javascript
 :filename: src/myplugin.mjs
-
+mkdir src
+touch src/myplugin.mjs
+```
 
 In this tutorial we will define a **directive** and play around with ways to control it.
 Other plugins you could define are **roles** and **transforms**.


### PR DESCRIPTION
- Adds a howto for plugin dependencies
- Adds the debug howto to the toc
- Fixes a typo in the tutorial
- Moves plugin howtos under a `Plugins` section since they're starting to get numerous!