### PR TITLE
✏️ Add authoring and admonition instructions

### DIFF
--- a/docs/author/authorship.md
+++ b/docs/author/authorship.md
@@ -1,0 +1,58 @@
+---
+authors:
+- name: Jo the Jovyan
+  affiliation: Planet Jupyter
+  twitter: projectjupyter
+  github: projectjupyter
+  url: "https://jupyter.org"
+---
+
+# Add authors and their information to a page
+
+Jupyter Book allows you to add authors and their information to a page in order to provide attribution, affiliations, etc.
+This page describes a few common use-cases and how to accomplish them.
+
+:::{note} See the top of this page for an example!
+:class: dropdown
+You can click on the author name to see more metadata about them.
+
+This page was written with the following frontmatter:
+
+```{code-block} markdown
+:filename: author/authorship.md
+---
+authors:
+  - name: Jo the Jovyan
+    affiliation: Planet Jupyter
+    twitter: projectjupyter
+---
+```
+:::
+
+## Add authors to a page or a book
+
+To add authors to your project, you can add them at the book level with the following key:
+
+```{code-block} yaml
+:filename: myst.yml
+
+project:
+  authors:
+    - name: Jo the Jovyan
+    - name: Planet Jupyter
+```
+
+To add authors at the page level, you can add the following to your [page metadata](xref:guide/frontmatter):
+
+```{code-block} markdown
+:filename: my-page.md
+---
+authors:
+  - name: Jo the Jovyan
+  - name: Planet Jupyter
+---
+```
+
+## Learn more
+
+- You can read more about the `authors` key in [the MyST frontmatter reference](xref:guide/frontmatter).

--- a/docs/author/roles-and-directives.md
+++ b/docs/author/roles-and-directives.md
@@ -1,0 +1,38 @@
+# Use roles and directives
+
+:::{seealso} See the MyST guide
+The [MyST authoring guide](xref:guide/typography) has more information about how to author content with roles and directives.
+:::
+
+## Use a basic directive
+
+Here's the basic usage of a directive, including arguments, options, and content:
+
+```markdown
+:::{my-directive} my-arg
+:option: my-option
+
+My directive content.
+:::
+```
+
+### Attach a class to directives
+
+Any directive can have classes attached to HTML outputs by using the `class` option like so:
+
+```markdown
+:::{my-directive} 
+:class: classone classtwo
+:::
+```
+
+These will be passed directly to the list of classes on the HTML element, so the value of `:class:` should follow the [HTML specification for the class attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class).
+
+## Use a basic role
+
+Here's the basic way to write a role in MyST Markdown:
+
+```{code-block} markdown
+:filename: mypage.md
+Here is a role: {my-role}`some content`.
+```

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -17,10 +17,11 @@ project:
     - src/xref.mjs
     - src/landing-page.mjs
     - src/directives.mjs
+    - src/admonition.mjs
   github: https://github.com/jupyter-book/jupyter-book
   toc:
     - file: index.md
-    - title: Get started
+    - title: Get Started
       file: start.md
       children:
         - file: start/install.md
@@ -41,8 +42,14 @@ project:
         - file: upgrade.md
     - title: How To
       children:
-        - file: execute/generate-myst.md
-        - title: Plugins
+        - title: Authoring & Writing
+          children:
+          - file: author/roles-and-directives.md
+          - file: author/authorship.md
+        - title: Execution & Computation
+          children:
+          - file: execute/generate-myst.md
+        - title: Plugins & Extensions
           children:
           - file: plugins/directives-and-roles.md
           - file: plugins/ast.md

--- a/docs/plugins/directives-and-roles.md
+++ b/docs/plugins/directives-and-roles.md
@@ -1,4 +1,4 @@
-# Create directives, roles, and transforms
+# Create custom directives, roles, and transforms
 
 This page provides minimal examples of how to create roles and directives in plugins.
 It focuses on the JavaScript plugin architecture, rather than the Executable Plugin architecture.
@@ -67,6 +67,37 @@ Example usage:
 My body
 ```
 ````
+
+## Create a custom admonition
+
+A common use-case for directive plugins is to create a custom admonition.
+Let's say that we want to create an admonition called "checkitout" that uses a specific color, and is always a dropdown.
+Here's plugin code you can copy/paste into a file to accomplish this:
+
+```{literalinclude} ../src/admonition.mjs
+```
+
+You can then register this plugin in your `myst.yml` file like so:
+
+```{code} yaml
+:filename: myst.yml
+
+project:
+  plugins:
+    - src/admonition.mjs
+```
+
+Then we can use this admonition like so:
+
+````markdown
+```{checkitout} My title
+My body
+```
+````
+
+```{checkitout} My title
+My body
+```
 
 ## Create a role
 

--- a/docs/src/admonition.mjs
+++ b/docs/src/admonition.mjs
@@ -1,0 +1,38 @@
+/**
+ * A custom admonition that uses a specific color, and is always a dropdown.
+ */
+const myAdmonition = {
+  name: "checkitout",
+  doc: "A custom admonition that uses a specific color, and is always a dropdown.",
+  arg: { type: String, doc: "The title of the admonition." },
+  options: {
+    collapsed: { type: Boolean, doc: "Whether to collapse the admonition." },
+  },
+  body: { type: String, doc: "The body of the directive." },
+  run(data, vfile, ctx) {
+      const admonition = {
+        "type": "admonition",
+        "kind": "tip",
+        "class": "dropdown",
+        "children": [
+          {
+            "type": "admonitionTitle",
+            // The first ["children"][0] removes the MyST "tree" top-level node.
+            // The second ["children"] removes an unnecessary top-level paragraph node.
+            "children": ctx.parseMyst(data.arg.trim())["children"][0]["children"]
+          },
+          {
+            "type": "paragraph",
+            "children": ctx.parseMyst(data.body.trim())["children"][0]["children"]
+          }
+        ]
+    }
+    return [admonition];
+  }
+};
+const plugin = {
+  name: "My custom admonition",
+  directives: [myAdmonition],
+};
+
+export default plugin;


### PR DESCRIPTION
This adds a few extra pieces of content to our documentation based on some recent questions from people:

1. Add super basic "how to" instructions for directives and roles
2. Show how to add classes to directives
3. Show how to create a custom admonition with a plugin (we can update this in the future if there's a better way)
4. Show an example of adding authorship information metadata
5. A little rearranging for folder names