### PR TITLE
Rename branch from 'master' to 'main' in _config.yaml

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -37,7 +37,7 @@ html:
 
 repository:
   url: https://github.com/executablebooks/jupyter-book
-  branch: master
+  branch: main
   path_to_book: docs
 
 launch_buttons:


### PR DESCRIPTION
Rename default branch from master to main in `docs/_config_yaml`.
This should resolve the 404 error one gets when clicking on "Suggest edit" on any page of the book.

Resolves issues (probably not a complete list):
- resolves #2242
- resolves #2235 

This is my first pull request. Let me know if some things are not to standard.
Best Johannes