### PR TITLE
Update banner to use github issue

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -25,7 +25,7 @@ html:
   # Then we could link to the changelog in the *same* build of the docs.
   announcement: >
     ℹ️ Jupyter Book is being rebuilt on top of <a href="https://mystmd.org/">MyST-MD</a>.
-    See <a href="https://executablebooks.org/en/latest/blog/2024-05-20-jupyter-book-myst/">our blog post</a> for more information. 🚀
+    See <a href="https://github.com/jupyter-book/jupyter-book/issues/2281">GitHub Issue#2281</a> for more information. 🚀
   favicon: images/favicon.ico
   home_page_in_navbar: false
   use_edit_page_button: true

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -24,7 +24,7 @@ html:
   # (The documentation says only that HTML is allowed, nothing about the base URL is mentioned.)
   # Then we could link to the changelog in the *same* build of the docs.
   announcement: >
-    ℹ️ Jupyter Book 2 is being rebuilt on top of <a href="https://mystmd.org/">MyST Document Engine</a>.
+    ℹ️ Jupyter Book 2 is being rebuilt on top of the <a href="https://mystmd.org/">MyST Document Engine</a>.
     See the preview at <a href="https://next.jupyterbook.org">next.jupyterbook.org</a> and learn more at <a href="https://github.com/jupyter-book/jupyter-book/issues/2281">GitHub Issue#2281</a>. 🚀
   favicon: images/favicon.ico
   home_page_in_navbar: false

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -24,8 +24,8 @@ html:
   # (The documentation says only that HTML is allowed, nothing about the base URL is mentioned.)
   # Then we could link to the changelog in the *same* build of the docs.
   announcement: >
-    ℹ️ Jupyter Book is being rebuilt on top of <a href="https://mystmd.org/">MyST-MD</a>.
-    See <a href="https://github.com/jupyter-book/jupyter-book/issues/2281">GitHub Issue#2281</a> for more information. 🚀
+    ℹ️ Jupyter Book 2 is being rebuilt on top of <a href="https://mystmd.org/">MyST Document Engine</a>.
+    See the preview at <a href="https://next.jupyterbook.org">next.jupyterbook.org</a> and learn more at <a href="https://github.com/jupyter-book/jupyter-book/issues/2281">GitHub Issue#2281</a>. 🚀
   favicon: images/favicon.ico
   home_page_in_navbar: false
   use_edit_page_button: true


### PR DESCRIPTION
This updates our banner to use a GitHub issue for ongoing information on the 2.0 switch (instead of using a blog post). My reasoning is that we can use that issue as the "source of truth" for external people that want to learn more about this transition, what to expect, where to learn more, etc. This might change over time so better to use a github issue than a blog post.

Here's the issue:

- https://github.com/jupyter-book/jupyter-book/issues/2281

Any objections from the @jupyter-book/core-team about this? I'm open to alternative suggestions!