### PR TITLE
Update new issues template to point to discussions forum

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug.yml
@@ -1,28 +1,25 @@
-name: Jupyter Book 2 Pre-Release Bug Report
-description: File a bug report.
+name: 🐛 Bug Report
 title: "[Bug]: "
-labels: ["bug", "next"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to try out Jupyter Book 2 (pre-release).
-        We expect there to be bugs and breakages, and this issue template should help us to track them down. Please fill in the following form:
+        Thanks for opening up a bug report! To make sure that your report provides actionable information, please fill out the following fields:
   - type: textarea
     id: what-happened
     attributes:
-      label: What happened?
-      description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
+      label: What happened, and what did you expect to happen?
+      placeholder: |
+        When running command X, I expected Y to happen, but instead Z happened.
     validations:
       required: true
   - type: input
     id: version
     attributes:
-      label: Version
+      label: What version of Jupyter Book are you running?
       description: |
-        What version of Jupyter Book are you running?  
-        Please run `jupyter book -v` and report the result
+        Run `jupyter book -v` and report the result
       placeholder: v2.0.0a0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     about: Questions about Jupyter Book or MyST are in our community forum.
   - name: 💡 Request an enhancement
     url: https://github.com/orgs/jupyter-book/discussions/categories/ideas
-    about: Ideas for new functionality and improvements to the Jupyter Book ecosystem.
+    about: Ideas for new functionality and improvements to Jupyter Book and MyST are in our community forum.
 blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 contact_links:
-  - name: Questions and Conversation 💬
-    url: https://github.com/orgs/jupyter-book/discussions
-    about: Ask questions, request enhancements, discuss computational workflows, and more. Most conversations should happen here, not in issues.
+  - name: ❓ Ask a question
+    url: https://github.com/orgs/jupyter-book/discussions/categories/q-a
+    about: Questions about Jupyter Book or MyST are in our community forum.
+  - name: 💡 Request an enhancement
+    url: https://github.com/orgs/jupyter-book/discussions/categories/ideas
+    about: Ideas for new functionality and improvements to the Jupyter Book ecosystem.
 blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
+contact_links:
+  - name: Questions and Conversation 💬
+    url: https://github.com/orgs/jupyter-book/discussions
+    about: Ask questions, request enhancements, discuss computational workflows, and more. Most conversations should happen here, not in issues.
 blank_issues_enabled: true


### PR DESCRIPTION
This adds a link to the Jupyter Book discussion forum for "new issue" templates.

I also propose that we update our "bug report" issue to just be a general bug report, not something "specific" to Jupyter Book 2. However we should make clear in the issue template that users should specify if this relates to JB 1 or 2.

This way, the new issue button menu should look like this:

1. Open a bug report
2. Open a blank issue
3. Ask a question (links to forum)
4. Request an enhancement (links to forum)

Over time, if people are still opening unhelpful blank issues and not using the forum, then we can consider removing that option so only maintainers can open blank issues.
