### PR TITLE
Add description back to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug.yml
@@ -1,5 +1,6 @@
 name: 🐛 Bug Report
 title: "[Bug]: "
+description: File a bug report.
 labels: ["bug"]
 body:
   - type: markdown


### PR DESCRIPTION
We accidentally deleted the description field, which isn't allowed