### PR TITLE
🪢 Loosen PyPI dependencies for nodeenv etc.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ env-var = "JUPYTER_BOOK_PACKAGE_VARIANT"
 # Ensure that we only bring in nodeenv for PyPI
 [tool.hatch.build.hooks.selector.variants.pypi]
 dependencies = [
-  "platformdirs~=4.2.2",
-  "nodeenv~=1.9.1"
+  "platformdirs>=4.2.2",
+  "nodeenv>=1.9.1"
 ]
 
 # Conda-forge has no additional dependencies to the `project.dependencies`


### PR DESCRIPTION
The PyPI dependencies block in pyproject.toml

https://github.com/jupyter-book/jupyter-book/blob/a4adf9f618180e92ab7b07d11ca08db6d5cfc04b/pyproject.toml#L48-L53

is too strict, causing installations to fail for locking solves with environments that also specify these.