### PR TITLE
Convert readthedocs pushd to cd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,6 @@ build:
   commands:
     - npm install -g mystmd
     - mkdir -p $READTHEDOCS_OUTPUT/html/
-    - pushd docs
+    - cd docs
     - BASE_URL="/$READTHEDOCS_LANGUAGE/$READTHEDOCS_VERSION" myst build --html
     - cp -a _build/html/. "$READTHEDOCS_OUTPUT/html" && rm -r _build


### PR DESCRIPTION
I wanted to see how the RTD integration was going, and realized that our builds are failing because `pushd` isn't on the build system, so this is a quick PR to get that working:

![CleanShot 2025-01-14 at 11 44 07](https://github.com/user-attachments/assets/a966fab6-065a-4a9e-8881-3b9af4240e16)
