### PR TITLE
cd within same command as build for RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,5 @@ build:
   commands:
     - npm install -g mystmd
     - mkdir -p $READTHEDOCS_OUTPUT/html/
-    - cd docs
-    - BASE_URL="/$READTHEDOCS_LANGUAGE/$READTHEDOCS_VERSION" myst build --html
-    - cp -a _build/html/. "$READTHEDOCS_OUTPUT/html" && rm -r _build
+    - cd docs/ && BASE_URL="/$READTHEDOCS_LANGUAGE/$READTHEDOCS_VERSION" myst build --html
+    - cp -a docs/_build/html/. "$READTHEDOCS_OUTPUT/html" && rm -r docs/_build


### PR DESCRIPTION
This uses the same build customization pattern recommended by RTD:

https://blog.readthedocs.com/build-customization/