### PR TITLE
Add extra links to the upgrading docs page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,11 +12,13 @@ site:
 Jupyter {orange}`Book`
 :::
 
-:::::{grid} 1 2 2 2
-::::{grid-item}
+::::::{grid} 1 2 2 2
+:::::{grid-item}
 {large}`Jupyter Book allows you to create documents and knowledge bases that are **reusable**, **reproducible**, and **interactive**.`
-::::
-::::{grid-item}
+:::::
+:::::{grid-item}
+::::{tab-set}
+:::{tab-item} Start Fresh
 
 ```{code-block} bash
 :filename: Jupyter Book quickstart
@@ -25,8 +27,22 @@ pip install jupyter-book
 jupyter book start
 ```
 
-::::
+Then check out the [documentation](./start.md)!
+:::
+:::{tab-item} Upgrade from Jupyter Book 1.0
+```{code-block} bash
+:filename: Jupyter Book upgrade
+:class: hi
+pip install --pre "jupyter-book>=2.0"
+jupyter book
+```
+
+You can find more information in the [upgrading tutorial](./upgrade.md)!
+:::
+
+
 :::::
+::::::
 
 +++ {"class": "col-body-outset"}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ pip install jupyter-book
 jupyter book start
 ```
 
-Then check out the [documentation](./start.md)!
+Then check out the [Jupyter Book documentation](./start.md)!
 :::
 :::{tab-item} Upgrade from Jupyter Book 1.0
 ```{code-block} bash

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -39,7 +39,6 @@ project:
         - file: tutorial/export.md
         - file: tutorial/jupyterlab.md
         - file: tutorial/plugins.md
-        - file: upgrade.md
     - title: How To
       children:
         - title: Authoring & Writing
@@ -55,6 +54,7 @@ project:
           - file: plugins/ast.md
           - file: plugins/debug.md
           - file: plugins/dependencies.md
+    - file: upgrade.md
     - title: About Jupyter Book
       children:
         - file: about/toolchain.md


### PR DESCRIPTION
I had some trouble finding the upgrading documentation from JB1, so I made 2 changes here:

1. Add a tab on the index page with the Quickstart to include upgrading instructions
2. Move the upgrading page (back?) the to top level of the TOC

My guess is that this will be one of the most viewed pages on the docs for a good while, so keeping the page highly visible would IMO be a net benefit. Thanks for the great project!