### PR TITLE
fix push it to github pages using github workflow

### DIFF
--- a/docs/publish/gh-pages.md
+++ b/docs/publish/gh-pages.md
@@ -77,14 +77,16 @@ jobs:
     permissions:
       pages: write
       id-token: write
+    environment:
+      name: github-pages
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Install dependencies
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
 
     - name: Install dependencies
       run: |
@@ -95,7 +97,7 @@ jobs:
     # execute:
     #   execute_notebooks: cache
     - name: cache executed notebooks
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: _build/.jupyter_cache
         key: jupyter-book-cache-${{ hashFiles('requirements.txt') }}
@@ -107,14 +109,14 @@ jobs:
 
     # Upload the book's HTML as an artifact
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: "_build/html"
 
     # Deploy the book's HTML to GitHub Pages
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4
 ```
 
 


### PR DESCRIPTION
fix push it to github pages using github workflowm, changing the version, for actions/upload-pages-artifact@v2 relies on actions/upload-artifact@v3, which is deprecated. I update to the latest version that works for my jupyter-book and the deploy was successful