### PR TITLE
DOC: Update GH Pages Publishing Guidance

### DIFF
--- a/docs/publish/gh-pages.md
+++ b/docs/publish/gh-pages.md
@@ -107,14 +107,14 @@ jobs:
 
     # Upload the book's HTML as an artifact
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: "_build/html"
 
     # Deploy the book's HTML to GitHub Pages
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4
 ```
 
 


### PR DESCRIPTION
This PR fixes the example GitHub workflow provided on the Jupyter Book docs site for recently deprecated workflows (https://jupyterbook.org/en/stable/publish/gh-pages.html). Hopefully this helps clarify anything for users that have used this page to get their GitHub Pages working from the get-go.

Under the hood for `actions/upload-pages-artifact@v2` relies on `actions/upload-artifact@v3`, which is deprecated as of January 30th (https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). In turn, when updating to v3, `actions/deploy-pages@v2` is no longer compatible, and must also be updated to the latest version.

There is no open issue on this, but I just ran into the problem today on one of my projects, so I assume leaving this unchanged will cause some headaches for folks down the road relying on this guide.