### PR TITLE
📝 Drop reference to execution workaround, as it does not work

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -46,9 +46,9 @@ project:
           children:
           - file: author/roles-and-directives.md
           - file: author/authorship.md
-        - title: Execution & Computation
-          children:
-          - file: execute/generate-myst.md
+          #        - title: Execution & Computation
+          #          children:
+          #          - file: execute/generate-myst.md
         - title: Plugins & Extensions
           children:
           - file: plugins/directives-and-roles.md


### PR DESCRIPTION
The workaround detailed in #2256 does not actually work properly — `include`s are evaluated before execution.

We really just need to fix execution. For now, I'm removing this guide from the ToC.

cc @choldgraf 