### PR TITLE
🔼 Bump `myst-cli` version for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "core-js": "^3.31.1",
                 "esbuild": "^0.17.19",
                 "js-yaml": "^4.1.0",
-                "myst-cli": "^1.3.23",
+                "myst-cli": "^1.3.24",
                 "npm-run-all": "^4.1.5",
                 "prettier": "latest",
                 "rimraf": "^5.0.1",
@@ -2564,9 +2564,9 @@
             }
         },
         "node_modules/docx/node_modules/@types/node": {
-            "version": "18.19.76",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.76.tgz",
-            "integrity": "sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==",
+            "version": "18.19.83",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.83.tgz",
+            "integrity": "sha512-D69JeR5SfFS5H6FLbUaS0vE4r1dGhmMBbG4Ed6BNS4wkDK8GZjsdCShT5LCN59vOHEUHnFCY9J4aclXlIphMkA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2574,9 +2574,9 @@
             }
         },
         "node_modules/docx/node_modules/nanoid": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "dev": true,
             "funding": [
                 {
@@ -2600,9 +2600,9 @@
             "license": "MIT"
         },
         "node_modules/doi-utils": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/doi-utils/-/doi-utils-2.0.4.tgz",
-            "integrity": "sha512-zmVJ/mCtiWgvrFKPByDGesJ+5Q0Crcspa8JTwvn6qEAtuAvqVOowKXyikg2EQQz188q8no9Uaho3P32FpNgvNA==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/doi-utils/-/doi-utils-2.0.5.tgz",
+            "integrity": "sha512-BAaEF9L9KqJmQfk1frtgAySPnwOdaY2UzZ85XvFAMLdGeqrH/GiwIziQU2y3WgrCuQ0ng74bq5uYBo8Qma/WqA==",
             "dev": true,
             "license": "MIT"
         },
@@ -6362,9 +6362,9 @@
             }
         },
         "node_modules/myst-cli": {
-            "version": "1.3.23",
-            "resolved": "https://registry.npmjs.org/myst-cli/-/myst-cli-1.3.23.tgz",
-            "integrity": "sha512-fUkwWbPwkrN7PVCCsti/lDRCpy8MEVqIp+L5GbsM53qLhyNpRoRlrOQKU1svF1LPZUvt9qGcB5obn4kmv25Iiw==",
+            "version": "1.3.25",
+            "resolved": "https://registry.npmjs.org/myst-cli/-/myst-cli-1.3.25.tgz",
+            "integrity": "sha512-OGOIit6v7QwJ4iTn6+jg6SDZ+UEaeeff1Mu/MbDPInVx8kbMXdIRx1qUghhOvMdZ2fIDl4Loko2DeEVtS2hr8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6380,7 +6380,7 @@
                 "commander": "^10.0.1",
                 "cors": "^2.8.5",
                 "docx": "^7.5.0",
-                "doi-utils": "^2.0.4",
+                "doi-utils": "^2.0.5",
                 "express": "^4.18.2",
                 "fs-extra": "^11.1.1",
                 "get-port": "^6.1.2",
@@ -6395,8 +6395,8 @@
                 "meca": "^1.0.8",
                 "mime-types": "^2.1.35",
                 "myst-cli-utils": "^2.0.11",
-                "myst-common": "^1.7.8",
-                "myst-config": "^1.7.8",
+                "myst-common": "^1.7.10",
+                "myst-config": "^1.7.10",
                 "myst-execute": "^0.1.2",
                 "myst-ext-button": "^0.0.1",
                 "myst-ext-card": "^1.0.9",
@@ -6406,18 +6406,18 @@
                 "myst-ext-proof": "^1.0.12",
                 "myst-ext-reactive": "^1.0.9",
                 "myst-ext-tabs": "^1.0.9",
-                "myst-frontmatter": "^1.7.8",
-                "myst-parser": "^1.5.11",
+                "myst-frontmatter": "^1.7.10",
+                "myst-parser": "^1.5.12",
                 "myst-spec": "^0.0.5",
-                "myst-spec-ext": "^1.7.8",
+                "myst-spec-ext": "^1.7.10",
                 "myst-templates": "^1.0.23",
-                "myst-to-docx": "^1.0.13",
-                "myst-to-jats": "^1.0.32",
+                "myst-to-docx": "^1.0.14",
+                "myst-to-jats": "^1.0.33",
                 "myst-to-md": "^1.0.15",
                 "myst-to-tex": "^1.0.41",
                 "myst-to-typst": "^0.0.30",
                 "myst-toc": "^0.1.2",
-                "myst-transforms": "^1.3.31",
+                "myst-transforms": "^1.3.33",
                 "nanoid": "^4.0.0",
                 "nbtx": "^0.2.3",
                 "node-fetch": "^3.3.1",
@@ -6455,14 +6455,14 @@
             }
         },
         "node_modules/myst-common": {
-            "version": "1.7.8",
-            "resolved": "https://registry.npmjs.org/myst-common/-/myst-common-1.7.8.tgz",
-            "integrity": "sha512-en8lBODpD+Om1LGVy2hSnNcYJ0VN7oc3aomE9UhIUCQQJwWxlccWEAhRsAz3D8sB0NDS3InBGgwd2o0jmdx61A==",
+            "version": "1.7.10",
+            "resolved": "https://registry.npmjs.org/myst-common/-/myst-common-1.7.10.tgz",
+            "integrity": "sha512-DEeFwDvtF7HiUkfvW44YuVMhgSHSuQ1bG40/u1lotyv1KTMP0P7kc63vSZcaEntRnVzTqtdWaEuw8I16QT0RCg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mdast": "^3.0.0",
-                "myst-frontmatter": "^1.7.8",
+                "myst-frontmatter": "^1.7.10",
                 "myst-spec": "^0.0.5",
                 "nanoid": "^4.0.0",
                 "unified": "^10.1.2",
@@ -6474,29 +6474,29 @@
             }
         },
         "node_modules/myst-config": {
-            "version": "1.7.8",
-            "resolved": "https://registry.npmjs.org/myst-config/-/myst-config-1.7.8.tgz",
-            "integrity": "sha512-3bGuujVyGX+bRi/TnL23mGPBH0wogctLjgmu/vT08xjfhFnrOtfUAFUt2prnegmjsey2JWTBxr6nmUdOxQ53Fg==",
+            "version": "1.7.10",
+            "resolved": "https://registry.npmjs.org/myst-config/-/myst-config-1.7.10.tgz",
+            "integrity": "sha512-pv1Ez53OWgd/Gqxf6StPrD1HhChuQKrLFD4kWFnka9VTHzSWHkuxriMuej63llPYL2h5V/HGMdZg+G92Kkb1Bw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "myst-common": "^1.7.8",
-                "myst-frontmatter": "^1.7.8",
+                "myst-common": "^1.7.10",
+                "myst-frontmatter": "^1.7.10",
                 "simple-validators": "^1.1.0"
             }
         },
         "node_modules/myst-directives": {
-            "version": "1.5.11",
-            "resolved": "https://registry.npmjs.org/myst-directives/-/myst-directives-1.5.11.tgz",
-            "integrity": "sha512-xq2c/3myLXK30TqQooRnzxwHZOSmmfXxlaWrcC6jYYN3WMlfvxwXP238xBwNVvFHWDE/q2aLiYLl3LNTeC4C+Q==",
+            "version": "1.5.12",
+            "resolved": "https://registry.npmjs.org/myst-directives/-/myst-directives-1.5.12.tgz",
+            "integrity": "sha512-pptHG0SxCPNkwenQ1FVx2J6Uk3bxtO5WLBSE5mS82Ds3IZPVSJaeOAJtE6NpJlHlm1J8PbpRXGpIA1jDKMk49g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.2",
                 "csv-parse": "^5.5.5",
                 "js-yaml": "^4.1.0",
-                "myst-common": "^1.7.8",
-                "myst-spec-ext": "^1.7.8",
+                "myst-common": "^1.7.9",
+                "myst-spec-ext": "^1.7.9",
                 "nanoid": "^4.0.2",
                 "unist-util-select": "^4.0.3",
                 "vfile": "^5.3.7"
@@ -6628,14 +6628,14 @@
             }
         },
         "node_modules/myst-frontmatter": {
-            "version": "1.7.8",
-            "resolved": "https://registry.npmjs.org/myst-frontmatter/-/myst-frontmatter-1.7.8.tgz",
-            "integrity": "sha512-xyn7KUPBk1oGp0ovX0Nx/AgXceJd9zykPYFHRBlUr4dlLt0AVMyFaU8VDuFDNw0MiW1bAT0remYq4uJLGGpHgQ==",
+            "version": "1.7.10",
+            "resolved": "https://registry.npmjs.org/myst-frontmatter/-/myst-frontmatter-1.7.10.tgz",
+            "integrity": "sha512-TT9Fw3FSEK7eZ16WkFLS6MOFEpBbDIDuV8AxRoAyAQfC9D7vC2qmkOVWSd0+cug2PVpNdoWCFkBJOjeEKM7Dmg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "credit-roles": "^2.1.0",
-                "doi-utils": "^2.0.4",
+                "doi-utils": "^2.0.5",
                 "myst-toc": "^0.1.2",
                 "orcid": "^1.0.0",
                 "simple-validators": "^1.1.0",
@@ -6643,9 +6643,9 @@
             }
         },
         "node_modules/myst-parser": {
-            "version": "1.5.11",
-            "resolved": "https://registry.npmjs.org/myst-parser/-/myst-parser-1.5.11.tgz",
-            "integrity": "sha512-qlZ8PQMms8MKz5p0qlcGUiddFdQI7UcljCida8wJNB6M8R5WOkU0J/gBptfMUWA1q5JOdA07XrpS2jQy5hoCXQ==",
+            "version": "1.5.12",
+            "resolved": "https://registry.npmjs.org/myst-parser/-/myst-parser-1.5.12.tgz",
+            "integrity": "sha512-IrPUe3sQOsdTfg6hNhnDWIQitLqYXkzuTkh3cQciN4QwvMcJ32ayBtijjCEEyEkL5rcDkxaSpQgpUK7NvSZ71Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6659,9 +6659,9 @@
                 "markdown-it-myst": "1.0.10",
                 "markdown-it-myst-extras": "0.3.0",
                 "markdown-it-task-lists": "^2.1.1",
-                "myst-common": "^1.7.8",
-                "myst-directives": "^1.5.11",
-                "myst-roles": "^1.5.11",
+                "myst-common": "^1.7.9",
+                "myst-directives": "^1.5.12",
+                "myst-roles": "^1.5.12",
                 "myst-spec": "^0.0.5",
                 "unified": "^10.1.1",
                 "unist-builder": "^3.0.0",
@@ -6672,14 +6672,14 @@
             }
         },
         "node_modules/myst-roles": {
-            "version": "1.5.11",
-            "resolved": "https://registry.npmjs.org/myst-roles/-/myst-roles-1.5.11.tgz",
-            "integrity": "sha512-PGypuWu+KZ7oP7TgGWsYJ0kqILV2qILl6jJThB9BD1eLiMPpsLHwaI/mgZjdS7W3gzkMvU3kKr4gxx245mt7Cw==",
+            "version": "1.5.12",
+            "resolved": "https://registry.npmjs.org/myst-roles/-/myst-roles-1.5.12.tgz",
+            "integrity": "sha512-t2hIqbBhWP2gIz1UDhrmxmcf7duSsBN1x+Z06PG8PNqjRQ6QHwEeohpXTDc/f/8nPkS55+jdAczZdjh422CurA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "myst-common": "^1.7.8",
-                "myst-spec-ext": "^1.7.8"
+                "myst-common": "^1.7.9",
+                "myst-spec-ext": "^1.7.9"
             }
         },
         "node_modules/myst-spec": {
@@ -6690,9 +6690,9 @@
             "license": "MIT"
         },
         "node_modules/myst-spec-ext": {
-            "version": "1.7.8",
-            "resolved": "https://registry.npmjs.org/myst-spec-ext/-/myst-spec-ext-1.7.8.tgz",
-            "integrity": "sha512-j2rVC2dgFYKB+qEacfUnGSf2HjaKTvMmd0w7Fx2kFGDNkqSg0rq8EiTUdCD3N4nCr7GSf4CNOetr190ZG0IFkA==",
+            "version": "1.7.10",
+            "resolved": "https://registry.npmjs.org/myst-spec-ext/-/myst-spec-ext-1.7.10.tgz",
+            "integrity": "sha512-vQFaTGRT7KRCl0TQ9RuFCArAWFd5AQNMFZP+xWmm/NHH08q8NtNP2U1FTvc1v597XO1f7JJLBezToYBv39gxwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6720,25 +6720,25 @@
             }
         },
         "node_modules/myst-to-docx": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/myst-to-docx/-/myst-to-docx-1.0.13.tgz",
-            "integrity": "sha512-laXO4KGYAwWOzzbiYj5YOPaXEFuAy/ThIY/4xLQD4cKG67bBlgkq91zvKEpGNXiJdsozwL1iJK1b8XH0KOggVQ==",
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/myst-to-docx/-/myst-to-docx-1.0.14.tgz",
+            "integrity": "sha512-DtD7MUSfKrRxDnlWTMZakIv9H3IPzyGpxxRiXHreStBULAqSqC4NSnLCaBKKxUyHu9AI3dGwokwt3gi4eauBqw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "buffer-image-size": "^0.6.4",
                 "docx": "^7.3.0",
-                "myst-common": "^1.7.6",
-                "myst-frontmatter": "^1.7.6",
+                "myst-common": "^1.7.9",
+                "myst-frontmatter": "^1.7.9",
                 "myst-spec": "^0.0.5",
-                "myst-spec-ext": "^1.7.6",
+                "myst-spec-ext": "^1.7.9",
                 "unist-util-select": "^4.0.3"
             }
         },
         "node_modules/myst-to-html": {
-            "version": "1.5.11",
-            "resolved": "https://registry.npmjs.org/myst-to-html/-/myst-to-html-1.5.11.tgz",
-            "integrity": "sha512-CC5HU2FWloX0JNSp2dLV7tSwkUQ2F0YIMVej4b6aa8MQxoAgNtjgpVJCJv6vIfCFEVKUsLTIE9wNWzvTMsrYsA==",
+            "version": "1.5.12",
+            "resolved": "https://registry.npmjs.org/myst-to-html/-/myst-to-html-1.5.12.tgz",
+            "integrity": "sha512-meswh0aGHMZ6HOVehUsbDUFpifqPiM29Qve11x/oVVgH8O4bxdo/Y6phk1iepvOg/ew05cQh2IsczLuCy2FMZQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6749,7 +6749,7 @@
                 "mdast": "^3.0.0",
                 "mdast-util-find-and-replace": "^2.1.0",
                 "mdast-util-to-hast": "^12.3.0",
-                "myst-common": "^1.7.8",
+                "myst-common": "^1.7.9",
                 "rehype-format": "^4.0.1",
                 "rehype-parse": "^8.0.4",
                 "rehype-remark": "^9.1.2",
@@ -6803,23 +6803,23 @@
             }
         },
         "node_modules/myst-to-jats": {
-            "version": "1.0.32",
-            "resolved": "https://registry.npmjs.org/myst-to-jats/-/myst-to-jats-1.0.32.tgz",
-            "integrity": "sha512-s8W74riAO3d6dZ+sB1mwhe/wiZPY81xRPCZYxz8Py3ELEMaYrP/ju6k3XmHpX0ksmn6tvBsrjrln7jw03/dkFQ==",
+            "version": "1.0.33",
+            "resolved": "https://registry.npmjs.org/myst-to-jats/-/myst-to-jats-1.0.33.tgz",
+            "integrity": "sha512-hh4gLQOMS4ufwu3Ua3ijnFkMIqHk3q1jzOvkQ3aU9zRG0jYwR1OldXbwSFFqwoyFCPEl1DdtciRGvioHl9b8yA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "citation-js-utils": "^1.2.3",
                 "credit-roles": "^2.1.0",
-                "doi-utils": "^2.0.4",
+                "doi-utils": "^2.0.5",
                 "jats-tags": "^1.0.8",
                 "jats-utils": "^1.0.8",
                 "katex": "^0.15.2",
-                "myst-common": "^1.7.7",
-                "myst-frontmatter": "^1.7.7",
+                "myst-common": "^1.7.10",
+                "myst-frontmatter": "^1.7.10",
                 "myst-spec": "^0.0.5",
-                "myst-spec-ext": "^1.7.7",
-                "myst-transforms": "^1.3.30",
+                "myst-spec-ext": "^1.7.10",
+                "myst-transforms": "^1.3.33",
                 "nbtx": "^0.2.3",
                 "unified": "^10.1.2",
                 "unist-util-remove": "^3.1.0",
@@ -6889,24 +6889,24 @@
             }
         },
         "node_modules/myst-transforms": {
-            "version": "1.3.31",
-            "resolved": "https://registry.npmjs.org/myst-transforms/-/myst-transforms-1.3.31.tgz",
-            "integrity": "sha512-DJqDAmeYhsNW59pG/lYQSpXRmtpNS8XWrysTQIAuXBQWwkts7hvZz+Tn2aVFTgmBtmk22sk9VSLUabWxrFYE2Q==",
+            "version": "1.3.33",
+            "resolved": "https://registry.npmjs.org/myst-transforms/-/myst-transforms-1.3.33.tgz",
+            "integrity": "sha512-hWamCqkYLxlOpkLOb0U26gExdxEz8fSHGhi+25xRglEVr6BnBFRvsx6GKu6tfr2vOwHjca0Ed+tlm+MQV+2Vkg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "doi-utils": "^2.0.4",
+                "doi-utils": "^2.0.5",
                 "hast-util-from-html": "^2.0.1",
                 "hast-util-to-mdast": "^8.3.1",
                 "intersphinx": "^1.0.2",
                 "js-yaml": "^4.1.0",
                 "katex": "^0.15.2",
                 "mdast-util-find-and-replace": "^2.1.0",
-                "myst-common": "^1.7.8",
-                "myst-frontmatter": "^1.7.8",
+                "myst-common": "^1.7.10",
+                "myst-frontmatter": "^1.7.10",
                 "myst-spec": "^0.0.5",
-                "myst-spec-ext": "^1.7.8",
-                "myst-to-html": "1.5.11",
+                "myst-spec-ext": "^1.7.10",
+                "myst-to-html": "1.5.12",
                 "rehype-parse": "^8.0.4",
                 "rehype-remark": "^9.1.2",
                 "unified": "^10.0.0",
@@ -7773,9 +7773,9 @@
             }
         },
         "node_modules/postcss/node_modules/nanoid": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "dev": true,
             "funding": [
                 {
@@ -8550,9 +8550,9 @@
             "license": "MIT"
         },
         "node_modules/sanitize-html": {
-            "version": "2.14.0",
-            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.14.0.tgz",
-            "integrity": "sha512-CafX+IUPxZshXqqRaG9ZClSlfPVjSxI0td7n07hk8QO2oO+9JDnlcL8iM8TWeOXOIBFgIOx6zioTzM53AOMn3g==",
+            "version": "2.15.0",
+            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.15.0.tgz",
+            "integrity": "sha512-wIjst57vJGpLyBP8ioUbg6ThwJie5SuSIjHxJg53v5Fg+kUK+AXlb7bK3RNXpp315MvwM+0OBGCV6h5pPHsVhA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
This PR bumps the `myst-cli` version in our lockfile, so that it is updated for packaging.