### PR TITLE
Fix macOS spelling in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug.yml
@@ -31,7 +31,7 @@ body:
       multiple: true
       options:
         - Linux
-        - Mac OS
+        - macOS
         - Windows
   - type: textarea
     id: logs


### PR DESCRIPTION
Very minor fix - macOS is spelt macOS, instead of Mac OS.