### PR TITLE
🧹 Cleanups of casing, etc. in documentation

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -21,7 +21,7 @@ project:
   github: https://github.com/jupyter-book/jupyter-book
   toc:
     - file: index.md
-    - title: Get Started
+    - title: Get started
       file: start.md
       children:
         - file: start/install.md
@@ -39,21 +39,21 @@ project:
         - file: tutorial/export.md
         - file: tutorial/jupyterlab.md
         - file: tutorial/plugins.md
-    - title: How To
+    - title: How to
       children:
-        - title: Authoring & Writing
+        - title: Authoring & writing
           children:
-          - file: author/roles-and-directives.md
-          - file: author/authorship.md
+            - file: author/roles-and-directives.md
+            - file: author/authorship.md
           #        - title: Execution & Computation
           #          children:
           #          - file: execute/generate-myst.md
-        - title: Plugins & Extensions
+        - title: Plugins & extensions
           children:
-          - file: plugins/directives-and-roles.md
-          - file: plugins/ast.md
-          - file: plugins/debug.md
-          - file: plugins/dependencies.md
+            - file: plugins/directives-and-roles.md
+            - file: plugins/ast.md
+            - file: plugins/debug.md
+            - file: plugins/dependencies.md
     - file: upgrade.md
     - title: About Jupyter Book
       children:

--- a/docs/plugins/ast.md
+++ b/docs/plugins/ast.md
@@ -1,9 +1,13 @@
-# Generate MyST AST in plugins
+---
+title: Generate MyST AST in plugins
+short_title: Generate new AST
+---
 
 A common usecase with plugins involves generating MyST AST and inserting it into the document.
 This page covers a few ways that you can do so.
 
 (plugins:ctx)=
+
 ## Parse MyST markdown to AST in a directive or role
 
 The easiest way to generate MyST AST in a plugin is by using the `parseMyst` function in the `ctx` variable. It may be easier to parse MyST Markdown into AST nodes rather than [using the MyST sandbox](sandbox.md) to preview them.
@@ -46,7 +50,6 @@ const myDirective = {
 The example above puts a multi-line string onto one line by manually coding the `\n` characters.
 If you instead want to show a multi-line string in your code, you will need to remove the indentation manually, for example like the following:
 
-
 ```{code} javascript
 :filename: src/justacard.mjs
 const myDirective = {
@@ -63,6 +66,7 @@ ${data.body}
   },
 };
 ```
+
 :::
 
 ## Use the MyST Sandbox to identify card AST structure
@@ -80,36 +84,36 @@ Using [the MyST sandbox](https://mystmd.org/sandbox) to preview and show the AST
 :::{note} Click here to see the full output of the MyST sandbox
 :class: dropdown
 {
-  "type": "root",
-  "children": [
-    {
-      "type": "block",
-      "children": [
-        {
-          "type": "card",
-          "children": [
-            {
-              "type": "cardTitle",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "My title"
-                }
-              ]
-            },
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "My card body."
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
+"type": "root",
+"children": [
+{
+"type": "block",
+"children": [
+{
+"type": "card",
+"children": [
+{
+"type": "cardTitle",
+"children": [
+{
+"type": "text",
+"value": "My title"
+}
+]
+},
+{
+"type": "paragraph",
+"children": [
+{
+"type": "text",
+"value": "My card body."
+}
+]
+}
+]
+}
+]
+}
+]
 }
 :::

--- a/docs/plugins/ast.md
+++ b/docs/plugins/ast.md
@@ -71,11 +71,9 @@ ${data.body}
 
 ## Use the MyST Sandbox to identify card AST structure
 
-The [MyST interactive sandbox](https://mystmd.org/sandbox) is a great way to explore what MyST looks like when it is rendered, and what its underlying AST structure looks like.
+The [MyST interactive sandbox](https://mystmd.org/sandbox) is a great way to explore what MyST looks like when it is rendered, and what its underlying AST structure looks like. This is particularly useful if you're generating MyST AST from scratch. For example, as part of a [plugin role or directive](../tutorial/plugins.md).
 
-This is particularly useful if you're generating MyST AST from scratch. For example, as part of a [plugin role or directive](../tutorial/plugins.md).
-
-For example, here's a video that shows how to use the MyST sandbox to explore the structure of a {myst:directive}`card` directive.
+Hre's a video that shows how to use the MyST sandbox to explore the structure of a {myst:directive}`card` directive.
 
 ```{figure} media/sandbox-demo.mp4
 Using [the MyST sandbox](https://mystmd.org/sandbox) to preview and show the AST of the {myst:directive}`card` directive.
@@ -84,7 +82,13 @@ Using [the MyST sandbox](https://mystmd.org/sandbox) to preview and show the AST
 :::{note} Click here to see the full output of the MyST sandbox
 :class: dropdown
 
-```json
+The output of the sandbox AST generator can be seen in @code:ast. The highlighted outer `root` and `block` nodes are always included in the output, and contain the interesting AST (in this case, a `card`).
+
+```{code} json
+:linenos:
+:emphasize-lines: 1-6,30-33
+:label: code:ast
+:caption: The AST of a card directive, produced by the MyST sandbox.
 {
   "type": "root",
   "children": [

--- a/docs/plugins/ast.md
+++ b/docs/plugins/ast.md
@@ -83,37 +83,41 @@ Using [the MyST sandbox](https://mystmd.org/sandbox) to preview and show the AST
 
 :::{note} Click here to see the full output of the MyST sandbox
 :class: dropdown
+
+```json
 {
-"type": "root",
-"children": [
-{
-"type": "block",
-"children": [
-{
-"type": "card",
-"children": [
-{
-"type": "cardTitle",
-"children": [
-{
-"type": "text",
-"value": "My title"
+  "type": "root",
+  "children": [
+    {
+      "type": "block",
+      "children": [
+        {
+          "type": "card",
+          "children": [
+            {
+              "type": "cardTitle",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "My title"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "My card body."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
-]
-},
-{
-"type": "paragraph",
-"children": [
-{
-"type": "text",
-"value": "My card body."
-}
-]
-}
-]
-}
-]
-}
-]
-}
+```
+
 :::

--- a/docs/plugins/debug.md
+++ b/docs/plugins/debug.md
@@ -1,8 +1,12 @@
-# Debug plugins
+---
+title: Debug plugins
+short_title: Debugging tips
+---
 
 This section describes a few ways to debug MyST plugins.
 
 (debug-mode)=
+
 ## Debug mode
 
 You can run MyST in **debug mode** to print a lot more information about what happens under the hood.
@@ -22,7 +26,7 @@ This allows you to inspect things at build time.
 For example, if you put the following in the `run(data)` function of a directive, it will show you the metadata in `data`.
 
 ```javascript
-console.log(data)
+console.log(data);
 ```
 
 Make sure to [run MyST in debug mode](#debug-mode).

--- a/docs/plugins/dependencies.md
+++ b/docs/plugins/dependencies.md
@@ -1,4 +1,7 @@
-# Install JavaScript dependencies with your plugin
+---
+title: Install JavaScript dependencies with your plugin
+short_title: Use packages from npm
+---
 
 You can expand your plugin's functionality by installing dependencies from the [npm package repository][npmjs]. You can install new dependencies by defining a `package.json` file[^1] in the same directory as your `myst.yml`[^2], and running `npm install`.
 
@@ -14,15 +17,15 @@ Here's an example `package.json` file that includes the `js-yaml` package, which
 ```
 
 By running `npm install`, we see:
+
 ```{code} shell
 $ npm install
 added 2 packages, and audited 3 packages in 898ms
 
 found 0 vulnerabilities
-````
+```
 
 You can then use the `js-yaml` package in your plugin code by importing it.
-
 
 For example, the following JavaScript snippet uses the `js-yaml` package and the `fs` package (already built into JavaScript) to load YAML data from a file.
 
@@ -37,7 +40,7 @@ const someData = yaml.load(fs.readFileSync("data.yml", "utf8"));
 
 Note that any plugins will be run from the root of the project, so set your file paths accordingly.
 
-## 
+##
 
 [^1]: For more information about `package.json` files, see the [Node.js documentation](https://docs.npmjs.com/cli/v9/using-npm/package-json) and [the MDN package documentation](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Package_management).
 [^2]: In fact, you can define a new `package.json` for each custom plugin, by defining your plugins in their own folders. There is little benefit to doing this, though.

--- a/docs/plugins/directives-and-roles.md
+++ b/docs/plugins/directives-and-roles.md
@@ -1,6 +1,9 @@
-# Create custom directives, roles, and transforms
+---
+title: Create custom roles, directives, and transforms
+short_title: Create roles, directives, & transforms
+---
 
-This page provides minimal examples of how to create roles and directives in plugins.
+This page provides minimal examples of how to create roles, directives, and transforms in plugins.
 It focuses on the JavaScript plugin architecture, rather than the Executable Plugin architecture.
 
 For each of the plugins below, you can register them by adding configuration to your `myst.yml` file like the following:
@@ -16,7 +19,7 @@ project:
 And then re-building your MyST site:
 
 ```{code} shell
-$ myst start
+$ juputer book start
 ```
 
 ## Create a directive
@@ -75,6 +78,7 @@ Let's say that we want to create an admonition called "checkitout" that uses a s
 Here's plugin code you can copy/paste into a file to accomplish this:
 
 ```{literalinclude} ../src/admonition.mjs
+
 ```
 
 You can then register this plugin in your `myst.yml` file like so:

--- a/docs/start.md
+++ b/docs/start.md
@@ -1,5 +1,5 @@
 ---
-title: Get Started
+title: Get started
 subtitle: Take your first steps with Jupyter Book.
 ---
 
@@ -14,7 +14,6 @@ For learning how to use Jupyter Book, this site will step you through **high-lev
 :::{tip} This documentation is a _work in progress_
 More comprehensive documentation on the underlying MyST Engine, or for specific use-cases like **single-page articles**, can be found at [the MyST Guide](xref:guide).
 :::
-
 
 ::::{grid} 1 2 2 2
 :::{card} Get started 🆕

--- a/docs/tutorial/plugins.md
+++ b/docs/tutorial/plugins.md
@@ -1,5 +1,5 @@
 ---
-title: Create Plugins in JavaScript
+title: Create plugins in JavaScript
 description: Plugins implemented in JavaScript are easily used across different projects, as they do not require any additional programs to be installed.
 ---
 


### PR DESCRIPTION
This PR makes a few docs cleanups:

- Use sentence case more consistently
- Run a linter over the YAML
- Fix missing code blocks
- Add short titles
- Add some description here and there