### PR TITLE
Update site assets to use Jupyter Book rather than meta

### DIFF
--- a/docs/site.yml
+++ b/docs/site.yml
@@ -17,6 +17,6 @@ site:
       - title: Report a bug 🐛
         url: https://github.com/jupyter-book/jupyter-book/issues
   options:
-    favicon: https://raw.githubusercontent.com/jupyter-book/meta/refs/heads/main/images/favicon.ico
-    logo: https://raw.githubusercontent.com/jupyter-book/meta/refs/heads/main/images/logo.svg
-    logo_dark: https://raw.githubusercontent.com/jupyter-book/meta/refs/heads/main/images/logo-dark.svg
+    favicon: https://raw.githubusercontent.com/jupyter-book/jupyter-book/refs/heads/next/docs/media/images/favicon.ico
+    logo: https://raw.githubusercontent.com/jupyter-book/jupyter-book/refs/heads/next/docs/media/images/logo.svg
+    logo_dark: https://raw.githubusercontent.com/jupyter-book/jupyter-book/refs/heads/next/docs/media/images/logo-dark.svg


### PR DESCRIPTION
I believe that @agoose77 deleted the `meta` repository, but we didn't update the jupyter book site header to use jupyter book assets for images / favicons. This does that.