### PR TITLE
Make the logo point to next.jupyterbook.org

### DIFF
--- a/docs/site.yml
+++ b/docs/site.yml
@@ -17,6 +17,7 @@ site:
       - title: Report a bug 🐛
         url: https://github.com/jupyter-book/jupyter-book/issues
   options:
+    logo_url: https://next.jupyterbook.org/
     favicon: https://raw.githubusercontent.com/jupyter-book/jupyter-book/refs/heads/next/docs/media/images/favicon.ico
     logo: https://raw.githubusercontent.com/jupyter-book/jupyter-book/refs/heads/next/docs/media/images/logo.svg
     logo_dark: https://raw.githubusercontent.com/jupyter-book/jupyter-book/refs/heads/next/docs/media/images/logo-dark.svg


### PR DESCRIPTION
This makes our logo point to next.jupyterbook.org for all sites that use the jupyter book theme. This gives the site more of a "unified website" vibe rather than changing the behavior of the logo based on the site you happen to be on. Thanks @stefanv for implementing this!