### PR TITLE
Update The Turing Way logo path

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -166,7 +166,7 @@ Explore this book {fas}`arrow-right`
 
 **The Turing Way**
 ^^^
-```{image} https://raw.githubusercontent.com/the-turing-way/the-turing-way/HEAD/book/website/figures/logo-detail-with-text.svg
+```{image} https://raw.githubusercontent.com/the-turing-way/the-turing-way/refs/heads/main/book/figures/logo-detail-with-text.svg
 :height: 100
 ```
 


### PR DESCRIPTION
The location of this logo in the repository has changed, so it was not being displayed on the JB website correctly.

(Incidentally, I did look to see if we could use [the image](https://book.the-turing-way.org/build/logo-detail-with-tex-d7288dba2ef85d69e094c0c994b463c4.svg) from https://book.the-turing-way.org but it looks like images are given a unique(ish) suffix, maybe a hash? So I wasn't sure if that URL would be reliable)