### PR TITLE
✍️ Fix install command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Jupyter {orange}`Book`
 ```{code-block} bash
 :emphasize-lines: 2
 :linenos:
-pip install --pre "jupyter-book>=2.0"
+pip install --pre "jupyter-book>=2.0.0b1"
 jupyter book start
 ```
 
@@ -34,7 +34,7 @@ Then check out the [Jupyter Book documentation](./start.md)!
 ```{code-block} bash
 :emphasize-lines: 2
 :linenos:
-pip install --pre "jupyter-book>=2.0"
+pip install --pre "jupyter-book>=2.0.0b1"
 jupyter book
 ```
 


### PR DESCRIPTION
The docs were recently updated to fix the install instructions. An annoying nuance is that `2.0.0` is `>` `2.0.0b0`, so `pip install --pre jupyter-book>=2.0.0` does not succeed.

Closes #2388 