### PR TITLE
✨ Use wildcard to define install version in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Jupyter {orange}`Book`
 ```{code-block} bash
 :emphasize-lines: 2
 :linenos:
-pip install --pre "jupyter-book>=2.0.0b1"
+pip install --pre "jupyter-book==2.*"
 jupyter book start
 ```
 
@@ -34,7 +34,7 @@ Then check out the [Jupyter Book documentation](./start.md)!
 ```{code-block} bash
 :emphasize-lines: 2
 :linenos:
-pip install --pre "jupyter-book>=2.0.0b1"
+pip install --pre "jupyter-book==2.*"
 jupyter book
 ```
 


### PR DESCRIPTION
@minrk reminded me that the wildcard operator matches pre-releases. Changing this will make the install command nicer to read.